### PR TITLE
Further SegmentVariant refactoring

### DIFF
--- a/src/main/java/com/vistatec/ocelot/segment/BaseSegmentVariant.java
+++ b/src/main/java/com/vistatec/ocelot/segment/BaseSegmentVariant.java
@@ -1,0 +1,200 @@
+package com.vistatec.ocelot.segment;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+
+public abstract class BaseSegmentVariant implements SegmentVariant {
+
+    protected abstract List<SegmentAtom> getAtoms();
+
+    protected abstract void setAtoms(List<SegmentAtom> atoms);
+
+    List<SegmentAtom> getAtomsForRange(int start, int length) {
+        List<SegmentAtom> atomsForRange = Lists.newArrayList();
+        int index = 0;
+        int end = start + length;
+
+        for (SegmentAtom atom : getAtoms()) {
+            if (index >= end) {
+                return atomsForRange;
+            }
+            if (index + atom.getLength() > start) {
+                if (atom instanceof CodeAtom) {
+                    atomsForRange.add(atom);
+                }
+                else {
+                    int min = Math.max(start - index, 0);
+                    int max = Math.min(end - index, atom.getData().length());
+                    atomsForRange.add(new TextAtom(atom.getData().substring(min, max)));
+                }
+            }
+            index += atom.getLength();
+        }
+        return atomsForRange;
+    }
+
+    public int getLength() {
+        int len = 0;
+        for (SegmentAtom atom : getAtoms()) {
+            len += atom.getLength();
+        }
+        return len;
+    }
+
+    @Override
+    public String getDisplayText() {
+        StringBuilder sb = new StringBuilder();
+        for (SegmentAtom atom : getAtoms()) {
+            sb.append(atom.getData());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public List<String> getStyleData(boolean verbose) {
+        ArrayList<String> textToStyle = new ArrayList<String>();
+
+        for (SegmentAtom atom : getAtoms()) {
+            if (atom instanceof CodeAtom && verbose) {
+                textToStyle.add(((CodeAtom)atom).getVerboseData());
+            }
+            else {
+                textToStyle.add(atom.getData());
+            }
+            textToStyle.add(atom.getTextStyle());
+        }
+        return textToStyle;
+    }
+
+    @Override
+    public boolean containsTag(int offset, int length) {
+        return checkForCode(offset, length).size() > 0;
+    }
+
+    @Override
+    public boolean canInsertAt(int offset) {
+        return checkForCode(offset, 0).size() == 0;
+    }
+
+    // Returns list of codes that occur in the specified range
+    private List<CodeAtom> checkForCode(int offset, int length) {
+        List<CodeAtom> codes = Lists.newArrayList();
+
+        int offsetEnd = offset + length;
+        int index = 0;
+        for (SegmentAtom atom : getAtoms()) {
+            if (index > offsetEnd) {
+                // We've drifted out of the danger zone
+                return codes;
+            }
+            if (atom instanceof CodeAtom) {
+                CodeAtom code = (CodeAtom)atom;
+                if (offsetEnd > index && offset < index + code.getLength()) {
+                    codes.add(code);
+                }
+            }
+            index += atom.getLength();
+        }
+        return codes;
+    }
+
+
+    @Override
+    public void replaceSelection(int selectionStart, int selectionEnd,
+            SegmentVariantSelection rsv) {
+
+        BaseSegmentVariant sv = (BaseSegmentVariant)rsv.getVariant(); // XXX
+        List<SegmentAtom> replaceAtoms = sv.getAtomsForRange(rsv.getSelectionStart(), 
+                rsv.getSelectionEnd() - rsv.getSelectionStart());
+
+        List<SegmentAtom> newAtoms = Lists.newArrayList();
+        newAtoms.addAll(getAtomsForRange(0, selectionStart));
+        newAtoms.addAll(replaceAtoms);
+        newAtoms.addAll(getAtomsForRange(selectionEnd, getLength()));
+
+        // Clean up codes that may be duplicates
+        Set<Integer> codeIds = new HashSet<Integer>();
+        List<SegmentAtom> cleanedAtoms = Lists.newArrayList();
+        // Strip any atoms that exist twice
+        for (SegmentAtom atom : newAtoms) {
+            if (atom instanceof CodeAtom) {
+                int id = ((CodeAtom)atom).getId();
+                if (!codeIds.contains(id)) {
+                    codeIds.add(id);
+                    cleanedAtoms.add(atom);
+                }
+            }
+            else {
+                cleanedAtoms.add(atom);
+            }
+        }
+        // Append any atoms that were deleted
+        List<CodeAtom> originalCodes = findCodes(getAtoms());
+        for (CodeAtom code : originalCodes) {
+            if (!codeIds.contains(code.getId())) {
+                cleanedAtoms.add(code);
+            }
+        }
+        setAtoms(cleanedAtoms);
+    }
+
+    @Override
+    public void modifyChars(int offset, int charsToReplace, String newText) {
+        int index = 0;
+        // The contract of this method is such that it never replaces a code,
+        // so the entire modification will always happen within a single text atom.
+        List<SegmentAtom> atoms = getAtoms();
+        List<SegmentAtom> newAtoms = Lists.newArrayList();
+        boolean done = false;
+        for (int i = 0; i < atoms.size(); i++) {
+            SegmentAtom atom = atoms.get(i);
+            if (atom instanceof TextAtom) {
+                if (index >= offset && !done) {
+                    // Do the text replacement
+                    String origText = atom.getData();
+                    int atomOffset = Math.max(offset - index, 0);
+                    newAtoms.add(new TextAtom(origText.substring(0, atomOffset)));
+                    if (newText != null) { // handle delete case
+                        newAtoms.add(new TextAtom(newText));
+                    }
+                    newAtoms.add(new TextAtom(origText.substring(atomOffset + charsToReplace)));
+                    done = true;
+                }
+                else {
+                    newAtoms.add(atom);
+                }
+            }
+            else if (atom instanceof CodeAtom) {
+                // I need to handle this separately because I might
+                // be inserting at the start of a segment that opens with a code.
+                // If it was just the text/code boundaries, I could handle them above.
+                if (index >= offset && !done) {
+                    newAtoms.add(new TextAtom(newText));
+                    done = true;
+                }
+                newAtoms.add(atom);
+            }
+            index += atom.getLength();
+        }
+        // Check for append
+        if (index == offset) {
+            newAtoms.add(new TextAtom(newText));
+        }
+        setAtoms(newAtoms);
+    }
+
+    private List<CodeAtom> findCodes(List<SegmentAtom> atoms) {
+        List<CodeAtom> codes = Lists.newArrayList();
+        for (SegmentAtom atom : atoms) {
+            if (atom instanceof CodeAtom) {
+                codes.add((CodeAtom)atom);
+            }
+        }
+        return codes;
+    }
+
+}

--- a/src/main/java/com/vistatec/ocelot/segment/CodeAtom.java
+++ b/src/main/java/com/vistatec/ocelot/segment/CodeAtom.java
@@ -1,0 +1,48 @@
+package com.vistatec.ocelot.segment;
+
+import net.sf.okapi.common.HashCodeUtil;
+
+public class CodeAtom implements SegmentAtom {
+    private int id;
+    private String data, verboseData;
+    public CodeAtom(int id, String data, String verboseData) {
+        this.id = id;
+        this.data = data;
+        this.verboseData = verboseData;
+    }
+    public int getId() {
+        return id;
+    }
+    @Override
+    public int getLength() {
+        return data.length();
+    }
+    @Override
+    public String getData() {
+        return data;
+    }
+    public String getVerboseData() {
+        return verboseData;
+    }
+    @Override
+    public String getTextStyle() {
+        return SegmentTextCell.tagStyle;
+    }
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o == null || !(o instanceof CodeAtom)) return false;
+        CodeAtom c = (CodeAtom)o;
+        return id == c.id && data.equals(c.data) && verboseData.equals(c.verboseData);
+    }
+    @Override
+    public int hashCode() {
+        int h = HashCodeUtil.hash(HashCodeUtil.SEED, id);
+        h = HashCodeUtil.hash(h, data);
+        return HashCodeUtil.hash(h, verboseData);
+    }
+    @Override
+    public String toString() {
+        return "[id=" + id + ", data='" + data + "', verbose='" + verboseData + "']";
+    }
+}

--- a/src/main/java/com/vistatec/ocelot/segment/SegmentAtom.java
+++ b/src/main/java/com/vistatec/ocelot/segment/SegmentAtom.java
@@ -1,0 +1,16 @@
+package com.vistatec.ocelot.segment;
+
+public interface SegmentAtom {
+    /**
+     * Length of this display data.
+     * @return
+     */
+    int getLength();
+
+    /**
+     * This is display data.
+     */
+    String getData();
+
+    String getTextStyle();
+}

--- a/src/main/java/com/vistatec/ocelot/segment/SegmentTextCell.java
+++ b/src/main/java/com/vistatec/ocelot/segment/SegmentTextCell.java
@@ -153,11 +153,6 @@ public class SegmentTextCell extends JTextPane {
         @Override
         public void replace(FilterBypass fb, int offset, int length, String str,
                 AttributeSet a) throws BadLocationException {
-            // Prevent copied codes from being pasted in, if the variant
-            // disallows this
-            if (!v.textIsInsertable(str)) {
-                return;
-            }
             if (length > 0) {
                 if (!v.containsTag(offset, length)) {
                     // Remove from cell editor

--- a/src/main/java/com/vistatec/ocelot/segment/SegmentVariant.java
+++ b/src/main/java/com/vistatec/ocelot/segment/SegmentVariant.java
@@ -64,14 +64,6 @@ public interface SegmentVariant {
     void modifyChars(int offset, int charsToReplace, String newText);
 
     /**
-     * Checks to see if text can be inserted.  This is to prevent 
-     * codes being pasted in, for example.
-     * @param o
-     * @return
-     */
-    boolean textIsInsertable(String text);
-
-    /**
      * Checks to see if an offset into the variant text is an insertable
      * position.  (For example, insertion in the middle of codes may be
      * disallowed.)
@@ -80,12 +72,19 @@ public interface SegmentVariant {
      */
     boolean canInsertAt(int offset);
 
+    /**
+     * Replace a selection (specified by offsets) with a selection from
+     * another segment variant.  (This method is currently unused and is
+     * intended as support for copy/paste.)
+     *
+     * @param selectionStart start of the selection to be replaced
+     * @param selectionEnd end of the selection to be replaced
+     * @param rsv content with which to replace the current selection
+     */
+    public void replaceSelection(int selectionStart, int selectionEnd,
+            SegmentVariantSelection rsv);
+
     @Override
     boolean equals(Object o);
 
-
-    //
-    // Methods for SegmentTextCell.SegmentFilter
-    //
-    // More factoring needed here
 }

--- a/src/main/java/com/vistatec/ocelot/segment/SegmentVariantSelection.java
+++ b/src/main/java/com/vistatec/ocelot/segment/SegmentVariantSelection.java
@@ -1,0 +1,39 @@
+package com.vistatec.ocelot.segment;
+
+/**
+ * Represents a clipboard selection of SegmentVariant content.
+ */
+public class SegmentVariantSelection {
+    private int row;
+    private SegmentVariant variant;
+    // Indexes into the display representation of variant
+    private int selectionStart, selectionEnd;
+
+    public SegmentVariantSelection(int row, SegmentVariant variant, int start, int end) {
+        this.row = row;
+        this.variant = variant;
+        this.selectionStart = start;
+        this.selectionEnd = end;
+    }
+
+    public int getRow() {
+        return row;
+    }
+
+    public SegmentVariant getVariant() {
+        return variant;
+    }
+
+    public int getSelectionStart() {
+        return selectionStart;
+    }
+
+    public int getSelectionEnd() {
+        return selectionEnd;
+    }
+    
+    @Override
+    public String toString() {
+        return "Row " + row + " [" + selectionStart + ", " + selectionEnd + "] of " + variant;
+    }
+}

--- a/src/main/java/com/vistatec/ocelot/segment/TextAtom.java
+++ b/src/main/java/com/vistatec/ocelot/segment/TextAtom.java
@@ -1,0 +1,35 @@
+package com.vistatec.ocelot.segment;
+
+public class TextAtom implements SegmentAtom {
+    private String text;
+    public TextAtom(String text) {
+        this.text = text;
+    }
+    @Override
+    public int getLength() {
+        return text.length();
+    }
+    @Override
+    public String getData() {
+        return text;
+    }
+    @Override
+    public String getTextStyle() {
+        return SegmentTextCell.regularStyle;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o == null || !(o instanceof TextAtom)) return false;
+        return text.equals(((TextAtom)o).text);
+    }
+    @Override
+    public int hashCode() {
+        return text.hashCode();
+    }
+    @Override
+    public String toString() {
+        return '[' + text + ']';
+    }
+}

--- a/src/test/java/com/vistatec/ocelot/segment/SimpleSegmentVariant.java
+++ b/src/test/java/com/vistatec/ocelot/segment/SimpleSegmentVariant.java
@@ -3,71 +3,49 @@ package com.vistatec.ocelot.segment;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vistatec.ocelot.ObjectUtils;
-
 /**
  * A text-only SegmentVariant implementation (no codes) to
  * simplify construction of Segment instances for tests.
  */
-public class SimpleSegmentVariant implements SegmentVariant {
-    private String text;
+public class SimpleSegmentVariant extends BaseSegmentVariant {
+    private List<SegmentAtom> atoms = new ArrayList<SegmentAtom>();;
+
+    private SimpleSegmentVariant() {
+    }
+
     public SimpleSegmentVariant(String text) {
-        this.text = text;
+        atoms.add(new TextAtom(text));
+    }
+
+    public SimpleSegmentVariant(List<SegmentAtom> atoms) {
+        this.atoms = atoms;
+    }
+
+    @Override
+    protected List<SegmentAtom> getAtoms() {
+        return atoms;
     }
 
     @Override
     public SegmentVariant createEmpty() {
-        return new SimpleSegmentVariant("");
+        return new SimpleSegmentVariant();
     }
 
     @Override
     public SegmentVariant createCopy() {
-        return new SimpleSegmentVariant(text);
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void setContent(SegmentVariant variant) {
-        this.text = ((SimpleSegmentVariant)variant).text;
-    }
-
-    @Override
-    public String getDisplayText() {
-        return text;
-    }
-
-    @Override
-    public List<String> getStyleData(boolean verbose) {
-        List<String> l = new ArrayList<String>(2);
-        l.add(text);
-        l.add(SegmentTextCell.regularStyle);
-        return l;
-    }
-
-    @Override
-    public boolean containsTag(int offset, int length) {
-        return false;
     }
 
     @Override
     public void modifyChars(int offset, int charsToReplace, String newText) {
-        text = text.substring(0, offset) + newText +
-               text.substring(offset + charsToReplace);
     }
 
     @Override
-    public boolean textIsInsertable(String text) {
-        return true;
-    }
-
-    @Override
-    public boolean canInsertAt(int offset) {
-        return true;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == this) return true;
-        if (o == null || !(o instanceof SimpleSegmentVariant)) return false;
-        return ObjectUtils.safeEquals(text, ((SimpleSegmentVariant)o).text);
+    protected void setAtoms(List<SegmentAtom> atoms) {
+        this.atoms = atoms;
     }
 }

--- a/src/test/java/com/vistatec/ocelot/segment/TestBaseSegmentVariant.java
+++ b/src/test/java/com/vistatec/ocelot/segment/TestBaseSegmentVariant.java
@@ -1,0 +1,71 @@
+package com.vistatec.ocelot.segment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import com.google.common.collect.Lists;
+
+public class TestBaseSegmentVariant {
+    SimpleSegmentVariant simpleSv, complexSv;
+
+    @Before
+    public void setup() {
+        List<SegmentAtom> atoms = Lists.newArrayList(
+                new TextAtom("A"),
+                new CodeAtom(1, "<b>", "<b>"),
+                new TextAtom("B"),
+                new CodeAtom(2, "</b>", "</b>")
+        );
+
+        simpleSv = new SimpleSegmentVariant(atoms);
+
+        complexSv = new SimpleSegmentVariant(Lists.newArrayList(
+                new TextAtom("ABC"),
+                new CodeAtom(1, "<b>", "<b>"),
+                new TextAtom("DEF"),
+                new CodeAtom(1, "</b>", "</b>")
+        ));
+    }
+
+    @Test
+    public void testGetAtomsForRange() {
+        // A < b > B < / B >
+        // 0 1 2 3 4 5 6 7 8
+        assertEquals((List<SegmentAtom>)new ArrayList<SegmentAtom>(),
+                     simpleSv.getAtomsForRange(0, 0));
+        assertEquals(Lists.newArrayList(new TextAtom("A")),
+                simpleSv.getAtomsForRange(0, 1));
+        assertEquals(Lists.newArrayList(new TextAtom("A"), new CodeAtom(1, "<b>", "<b>")),
+                simpleSv.getAtomsForRange(0,  2));
+        assertEquals(Lists.newArrayList(new TextAtom("A"), new CodeAtom(1, "<b>", "<b>")),
+                simpleSv.getAtomsForRange(0,  3));
+        assertEquals(Lists.newArrayList(new TextAtom("A"), new CodeAtom(1, "<b>", "<b>")),
+                simpleSv.getAtomsForRange(0,  4));
+        assertEquals(Lists.newArrayList(new TextAtom("A"), new CodeAtom(1, "<b>", "<b>"), new TextAtom("B")),
+                simpleSv.getAtomsForRange(0,  5));
+        assertEquals(Lists.newArrayList(new CodeAtom(1, "<b>", "<b>"), new TextAtom("B")),
+                simpleSv.getAtomsForRange(1, 4));
+        assertEquals(Lists.newArrayList(new CodeAtom(1, "<b>", "<b>"), new TextAtom("B")),
+                simpleSv.getAtomsForRange(2, 3));
+        assertEquals(Lists.newArrayList(new CodeAtom(1, "<b>", "<b>"), new TextAtom("B")),
+                simpleSv.getAtomsForRange(3, 2));
+        assertEquals(Lists.newArrayList(new TextAtom("A"), new CodeAtom(1, "<b>", "<b>"), 
+                                        new TextAtom("B"), new CodeAtom(2, "</b>", "</b>")),
+                simpleSv.getAtomsForRange(0, 8));
+
+        // A B C < b > D E F < / b >
+        // 0 1 2 3 4 5 6 7 8 9 0 1 2
+        assertEquals(Lists.newArrayList(new TextAtom("C"), new CodeAtom(1, "<b>", "<b>")),
+                complexSv.getAtomsForRange(2, 4));
+        assertEquals(Lists.newArrayList(new TextAtom("C"), new CodeAtom(1, "<b>", "<b>"), new TextAtom("D")),
+                complexSv.getAtomsForRange(2, 5));
+        assertEquals(Lists.newArrayList(new CodeAtom(1, "<b>", "<b>"), new TextAtom("D")),
+                complexSv.getAtomsForRange(3, 4));
+        assertEquals(Lists.newArrayList(new CodeAtom(1, "<b>", "<b>"), new TextAtom("DE")),
+                complexSv.getAtomsForRange(3, 5));
+    }
+}


### PR DESCRIPTION
This was part of the refactoring I did for copy/paste in 1.1 and never committed, since it was right before the 1.1 release.  I've removed the copy/paste parts, but I think this is still useful.  Basically, this will prevent us from having to re-implement some tedious string logic to support SegmentTextCell with the xliff 2.0 code.

Commit message:
    This changes the SV implementations to expose text and code "atoms",
    which are then manipulated by common code in BaseSegmentVariant.

```
This includes the replaceSelection() method, which isn't used
anywhere and is intended to be part of copy/paste support.
```
