### PR TITLE
OC-85 Display tag contents in left segment view and segment table mouseover

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,9 @@
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>3.0</version>
+      <!-- Guice AOP prevents breakpoints from working.
+           Un-comment to disable AOP for debugging purposes.
+      <classifier>no_aop</classifier>-->
     </dependency>
     <dependency>
     <groupId>org.apache.jena</groupId>

--- a/src/main/java/com/vistatec/ocelot/segment/view/SegmentDetailView.java
+++ b/src/main/java/com/vistatec/ocelot/segment/view/SegmentDetailView.java
@@ -64,7 +64,7 @@ public class SegmentDetailView extends JScrollPane {
         tableModel = new DetailTableModel();
         table = new JTable(tableModel);
         table.getTableHeader().setReorderingAllowed(false);
-        table.setDefaultRenderer(String.class, new TextRenderer());
+        table.setDefaultRenderer(Object.class, new TextRenderer());
         TableColumnModel tableColumnModel = table.getColumnModel();
         tableColumnModel.getColumn(0).setMinWidth(15);
         tableColumnModel.getColumn(0).setPreferredWidth(60);

--- a/src/main/java/com/vistatec/ocelot/segment/view/SegmentTextCell.java
+++ b/src/main/java/com/vistatec/ocelot/segment/view/SegmentTextCell.java
@@ -297,17 +297,23 @@ public class SegmentTextCell extends JTextPane {
 
     @Override
     public String getToolTipText(MouseEvent event) {
-        Point p = event.getPoint();
-        int offset = viewToModel(p);
+        String text = getToolTipText(event.getPoint());
+        return text == null ? super.getToolTipText(event) : text;
+    }
+
+    String getToolTipText(Point p) {
+        return getToolTipText(viewToModel(p));
+    }
+
+    String getToolTipText(int offset) {
         if (v != null && v.containsTag(offset, 0)) {
             SegmentAtom atom = v.getAtomAt(offset);
             if (atom instanceof CodeAtom) {
                 return ((CodeAtom) atom).getVerboseData();
             }
         }
-        return super.getToolTipText(event);
+        return null;
     }
-
 
 	/**
      * Handles edit behavior in segment text cell.

--- a/src/main/java/com/vistatec/ocelot/segment/view/SegmentView.java
+++ b/src/main/java/com/vistatec/ocelot/segment/view/SegmentView.java
@@ -40,6 +40,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.HeadlessException;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ContainerEvent;
@@ -249,6 +250,35 @@ public class SegmentView extends JScrollPane implements RuleListener,
             }
             return super.print(printMode, headerFormat, footerFormat, showPrintDialog, attr, interactive, service);
         }
+        
+		@Override
+		public String getToolTipText(MouseEvent event) {
+			int row = rowAtPoint(event.getPoint());
+			int col = columnAtPoint(event.getPoint());
+			Object o = getValueAt(row, col);
+			if (o instanceof SegmentVariant) {
+				// Table cells don't exist as components so we must materialize
+				// an actual component in order to figure out where in the text
+				// we are pointing.
+				TableCellRenderer renderer = getCellRenderer(row, col);
+				Component comp = renderer.getTableCellRendererComponent(this, o, false, false, row, col);
+				if (comp instanceof SegmentTextCell) {
+					SegmentTextCell cell = (SegmentTextCell) comp;
+					// Set the bounds of the component to match where the table
+					// cell was painted.
+					Rectangle rect = getCellRect(row, col, true);
+					cell.setBounds(rect);
+					Point p = event.getPoint();
+					// Convert from table coordinates to cell coordinates.
+					p.translate(-rect.x, -rect.y);
+					String tip = cell.getToolTipText(p);
+					if (tip != null) {
+						return tip;
+					}
+				}
+			}
+			return super.getToolTipText(event);
+		}
 	}
 
 	@Inject


### PR DESCRIPTION
# Display tag contents in left segment view
This was a one-line fix: The table cell renderer was already set up to do this, but the renderer was only set to be used with String values instead of all values.

# Display tag contents in segment table mouseover
Table cells do not exist as components; when drawing the table, a single renderer component is drawn repeatedly at each cell location and then discarded. So to tell what the mouse cursor is hovering over we materialize the `SegmentTextCell` rendering component and query it for the tooltip. I had already implemented verbose tag tooltips on `SegmentTextCell`s as part of tag D&D/editing.